### PR TITLE
Update to .NET 9.0 and upgrade package references

### DIFF
--- a/L4D2PlayStats.Core/L4D2PlayStats.Core.csproj
+++ b/L4D2PlayStats.Core/L4D2PlayStats.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
@@ -10,10 +10,10 @@
         <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
         <PackageReference Include="Azure.Identity" Version="1.13.1" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-        <PackageReference Include="L4D2PlayStats" Version="1.0.0.37" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+        <PackageReference Include="L4D2PlayStats" Version="1.0.0.38" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
         <PackageReference Include="AutoMapper" Version="13.0.1" />
         <PackageReference Include="FluentValidation" Version="11.10.0" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/L4D2PlayStats.FunctionApp/L4D2PlayStats.FunctionApp.csproj
+++ b/L4D2PlayStats.FunctionApp/L4D2PlayStats.FunctionApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
         <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     </PropertyGroup>
@@ -9,12 +9,12 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
         <PackageReference Include="AutoMapper" Version="13.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
         <PackageReference Include="Scrutor" Version="5.0.2" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ steps:
   displayName: 'Install .NET 8 SDK'
   inputs:
     packageType: 'sdk'
-    version: '8.x'
+    version: '9.x'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: DotNetCoreCLI@2

--- a/tests/L4D2PlayStats.Tests/L4D2PlayStats.Tests.csproj
+++ b/tests/L4D2PlayStats.Tests/L4D2PlayStats.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Updated target framework to .NET 9.0 for projects:
- L4D2PlayStats.Core.csproj
- L4D2PlayStats.FunctionApp.csproj
- L4D2PlayStats.Tests.csproj

Upgraded package references in L4D2PlayStats.Core.csproj and L4D2PlayStats.FunctionApp.csproj:
- L4D2PlayStats: 1.0.0.37 -> 1.0.0.38
- Microsoft.Extensions.Caching.Abstractions: 8.0.0 -> 9.0.0
- Microsoft.Extensions.Configuration.Abstractions: 8.0.0 -> 9.0.0
- Microsoft.Extensions.Configuration.Binder: 8.0.2 -> 9.0.0
- Microsoft.Azure.Functions.Worker.Sdk: 1.18.1 -> 2.0.0
- Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore: 1.3.2 -> 2.0.0
- Microsoft.Azure.Functions.Worker: 1.23.0 -> 2.0.0
- Microsoft.Extensions.Hosting: 8.0.1 -> 9.0.0
- Microsoft.Extensions.Caching.Memory: 8.0.1 -> 9.0.0

Updated azure-pipelines.yml to install .NET 9 SDK.